### PR TITLE
 Allow skipping to a specific test number or shrink result

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -34,6 +34,7 @@ module Hedgehog.Internal.Property (
   , DiscardCount(..)
   , ShrinkLimit(..)
   , ShrinkCount(..)
+  , ShrinkPath(..)
   , ShrinkRetries(..)
   , withTests
   , withDiscards
@@ -330,6 +331,12 @@ newtype ShrinkLimit =
 newtype ShrinkCount =
   ShrinkCount Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+-- | The path taken to reach a shrink state.
+--
+newtype ShrinkPath =
+  ShrinkPath [Int]
+  deriving (Eq, Ord, Show)
 
 -- | The number of times to re-run a test during shrinking. This is useful if
 --   you are testing something which fails non-deterministically and you want to

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -58,10 +58,11 @@ import           Hedgehog.Internal.Prelude
 import           Hedgehog.Internal.Property (CoverCount(..), CoverPercentage(..))
 import           Hedgehog.Internal.Property (Coverage(..), Label(..), LabelName(..))
 import           Hedgehog.Internal.Property (PropertyName(..), Log(..), Diff(..))
-import           Hedgehog.Internal.Property (ShrinkCount(..), ShrinkPath(..), PropertyCount(..))
+import           Hedgehog.Internal.Property (ShrinkCount(..), PropertyCount(..))
 import           Hedgehog.Internal.Property (TestCount(..), DiscardCount(..))
 import           Hedgehog.Internal.Property (coverPercentage, coverageFailures)
 import           Hedgehog.Internal.Property (labelCovered)
+import           Hedgehog.Internal.Property (ShrinkPath(..), shrinkPathCompress)
 
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
@@ -328,8 +329,8 @@ ppShrinkCount = \case
   ShrinkCount n ->
     ppShow n <+> "shrinks"
 
-ppShrinkPath :: ShrinkPath -> Doc a
-ppShrinkPath (ShrinkPath p) = ppShow $ reverse p
+ppShrinkPath :: TestCount -> ShrinkPath -> Doc a
+ppShrinkPath tests path = WL.text $ shrinkPathCompress tests path
 
 ppRawPropertyCount :: PropertyCount -> Doc a
 ppRawPropertyCount (PropertyCount n) =
@@ -753,7 +754,7 @@ ppResult name (Report tests discards coverage result) = do
             ppShrinkDiscard (failureShrinks failure) discards <>
             "." <#>
             "shrink path:" <+>
-            ppShrinkPath (failureShrinkPath failure)
+            ppShrinkPath tests (failureShrinkPath failure)
             <> "."
         ] ++
         ppCoverage tests coverage ++

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -156,6 +156,49 @@ takeSmallest size seed shrinks shrinkPath slimit retries updateUI = \case
       Right () ->
         return OK
 
+-- | Follow a given shrink path, instead of searching exhaustively. Assume that
+-- the end of the path is minimal, and don't try to shrink any further than
+-- that.
+--
+-- This evaluates the test for all the shrinks on the path, but not ones
+-- off-path. Because the generator is mixed with the test code, it's probably
+-- not possible to avoid this.
+skipToShrink ::
+     MonadIO m
+  => Size
+  -> Seed
+  -> ShrinkPath
+  -> (Progress -> m ())
+  -> NodeT m (Maybe (Either Failure (), Journal))
+  -> m Result
+skipToShrink size seed (ShrinkPath shrinkPath) updateUI =
+  go 0 (reverse shrinkPath)
+ where
+  go shrinks [] = \case
+    NodeT Nothing _ ->
+      pure GaveUp
+
+    NodeT (Just (x, (Journal logs))) _ ->
+      case x of
+        Left (Failure loc err mdiff) -> do
+          let
+            failure =
+              mkFailure size seed shrinks (ShrinkPath shrinkPath) Nothing loc err mdiff (reverse logs)
+
+          updateUI $ Shrinking failure
+          pure $ Failed failure
+
+        Right () ->
+          return OK
+
+  go shrinks (s0:ss) = \case
+    NodeT _ xs ->
+      case drop s0 xs of
+        [] -> pure GaveUp
+        (x:_) -> do
+          o <- runTreeT x
+          go (shrinks + 1) ss o
+
 checkReport ::
      forall m.
      MonadIO m
@@ -167,9 +210,14 @@ checkReport ::
   -> (Report Progress -> m ())
   -> m (Report Result)
 checkReport cfg size0 seed0 test0 updateUI = do
-  -- This should be a parameter, but that would need changes in hspec-hedgehog.
+  -- These should be parameters (or rather, combined as one parameter), but that
+  -- would need changes in hspec-hedgehog.
   mSkipToTest <-
     liftIO $ fmap (TestCount . read) <$> lookupEnv "HEDGEHOG_SKIP_TO_TEST"
+
+  -- We reverse before printing, so we have to reverse when reading as well.
+  mSkipToShrink <- liftIO $
+    fmap (ShrinkPath . reverse . read) <$> lookupEnv "HEDGEHOG_SKIP_TO_SHRINK"
 
   let
     test =
@@ -277,12 +325,18 @@ checkReport cfg size0 seed0 test0 updateUI = do
 
       else
         case Seed.split seed of
-          (s0, s1) -> case mSkipToTest of
+          (s0, s1) -> case (mSkipToTest, mSkipToShrink) of
             -- If the report says failed "after 32 tests", the test number that
             -- failed was 31, but we want the user to be able to skip to 32 and
             -- start with the one that failed.
-            Just n | n > tests + 1 ->
+            (Just n, _) | n > tests + 1 ->
               loop (tests + 1) discards (size + 1) s1 coverage0
+            (Just _, Just shrinkPath) -> do
+              node <-
+                runTreeT . evalGenT size s0 . runTestT $ unPropertyT test
+              let mkReport = Report (tests + 1) discards coverage0
+              mkReport
+               <$> skipToShrink size s0 shrinkPath (updateUI . mkReport) node
             _ -> do
               node@(NodeT x _) <-
                 runTreeT . evalGenT size s0 . runTestT $ unPropertyT test


### PR DESCRIPTION
Upstream: https://github.com/hedgehogqa/haskell-hedgehog/pull/454

Using environment variables, this lets the user either

* `HEDGEHOG_SKIP_TO_TEST`: Start testing at a specific test number, and then continue from there. If it fails it'll shrink, if it passes it'll move on to the next test. Or,
* `HEDGEHOG_SKIP_TO_SHRINK`: Test at a specific test number and shrink state. If it fails it won't shrink further, if it passes the test will pass. The shrink state is encoded as an alphanumeric string and printed below the test and shrink counts. It also runs the test at intermediate shrinks, ignoring the results; see discussion on the upstream PR.

Environment variables are a bad way to handle this, but it means we can use the feature now without also forking hspec-hedgehog.